### PR TITLE
Added links between some HTML and RST documents

### DIFF
--- a/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
+++ b/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
@@ -21,6 +21,7 @@ Table of content
 ----------------
 
 | `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
+| `Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
 
 | `Introduction`_
 | `Tutorial files`_

--- a/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
+++ b/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
@@ -21,7 +21,7 @@ Table of content
 ----------------
 
 | `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
-| `Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+| `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
 
 | `Introduction`_
 | `Tutorial files`_

--- a/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
+++ b/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
@@ -21,7 +21,6 @@ Table of content
 ----------------
 
 | `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
-| `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
 
 | `Introduction`_
 | `Tutorial files`_

--- a/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
+++ b/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst
@@ -15,10 +15,12 @@
 Variables and datatypes in Robot Framework
 ==========================================
 
-Version 0.4.3 / 30.05.2023 / by XC-CT/ECA3-Queckenstedt
+Version 0.4.4 / 21.06.2023 / by XC-CT/ECA3-Queckenstedt
 
 Table of content
 ----------------
+
+| `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
 
 | `Introduction`_
 | `Tutorial files`_

--- a/100_variables_and_datatypes/variables_and_datatypes.html
+++ b/100_variables_and_datatypes/variables_and_datatypes.html
@@ -378,10 +378,6 @@ limitations under the License. -->
 <h1>Table of content</h1>
 <div class="line-block">
 <div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></div>
-<div class="system-message">
-<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
-Duplicate explicit target name: &quot;tutorial main sections&quot;.</div>
-<div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
 </div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>

--- a/100_variables_and_datatypes/variables_and_datatypes.html
+++ b/100_variables_and_datatypes/variables_and_datatypes.html
@@ -378,6 +378,10 @@ limitations under the License. -->
 <h1>Table of content</h1>
 <div class="line-block">
 <div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></div>
+<div class="system-message">
+<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
+Duplicate explicit target name: &quot;tutorial main sections&quot;.</div>
+<div class="line"><a class="reference external" href="https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
 </div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>

--- a/100_variables_and_datatypes/variables_and_datatypes.html
+++ b/100_variables_and_datatypes/variables_and_datatypes.html
@@ -381,7 +381,7 @@ limitations under the License. -->
 <div class="system-message">
 <p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/100_variables_and_datatypes/doc_src/variables_and_datatypes.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
 Duplicate explicit target name: &quot;tutorial main sections&quot;.</div>
-<div class="line"><a class="reference external" href="https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
+<div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
 </div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>

--- a/100_variables_and_datatypes/variables_and_datatypes.html
+++ b/100_variables_and_datatypes/variables_and_datatypes.html
@@ -373,9 +373,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
-<p>Version 0.4.3 / 30.05.2023 / by XC-CT/ECA3-Queckenstedt</p>
+<p>Version 0.4.4 / 21.06.2023 / by XC-CT/ECA3-Queckenstedt</p>
 <div class="section" id="table-of-content">
 <h1>Table of content</h1>
+<div class="line-block">
+<div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></div>
+</div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>
 <div class="line"><a class="reference internal" href="#tutorial-files">Tutorial files</a></div>

--- a/900_building_testsuites/building_testsuites.html
+++ b/900_building_testsuites/building_testsuites.html
@@ -376,16 +376,9 @@ limitations under the License. -->
 <hr class="docutils" />
 <div class="section" id="table-of-content">
 <h1>Table of content</h1>
-<ol class="arabic">
-<li><p class="first"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></p>
-<div class="system-message">
-<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/900_building_testsuites/doc_src/building_testsuites.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
-<p>Duplicate explicit target name: &quot;tutorial main sections&quot;.</p>
-</div>
-<p><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></p>
-</li>
-<li><p class="first"><a class="reference internal" href="#introduction">Introduction</a></p>
-<ul class="simple">
+<ol class="arabic simple">
+<li><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></li>
+<li><a class="reference internal" href="#introduction">Introduction</a><ul>
 <li><a class="reference internal" href="#what-is-the-initial-situation">What is the initial situation?</a></li>
 <li><a class="reference internal" href="#how-to-handle-configuration-parameters-in-robot-framework">How to handle configuration parameters in Robot Framework?</a></li>
 <li><a class="reference internal" href="#how-to-realize-a-concrete-test-suites-management">How to realize a concrete test suites management?</a></li>
@@ -394,8 +387,7 @@ limitations under the License. -->
 <li><a class="reference internal" href="#how-to-activate-the-test-suites-management-in-robot-framework">How to activate the test suites management in Robot Framework?</a></li>
 </ul>
 </li>
-<li><p class="first"><a class="reference internal" href="#exercises">Exercises</a></p>
-</li>
+<li><a class="reference internal" href="#exercises">Exercises</a></li>
 </ol>
 </div>
 <div class="section" id="introduction">

--- a/900_building_testsuites/building_testsuites.html
+++ b/900_building_testsuites/building_testsuites.html
@@ -382,7 +382,7 @@ limitations under the License. -->
 <p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/900_building_testsuites/doc_src/building_testsuites.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
 <p>Duplicate explicit target name: &quot;tutorial main sections&quot;.</p>
 </div>
-<p><a class="reference external" href="https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></p>
+<p><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></p>
 </li>
 <li><p class="first"><a class="reference internal" href="#introduction">Introduction</a></p>
 <ul class="simple">

--- a/900_building_testsuites/building_testsuites.html
+++ b/900_building_testsuites/building_testsuites.html
@@ -377,9 +377,8 @@ limitations under the License. -->
 <div class="section" id="table-of-content">
 <h1>Table of content</h1>
 <ol class="arabic simple">
-<li><a class="reference internal" href="#introduction">Introduction</a></li>
-</ol>
-<ul class="simple">
+<li><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></li>
+<li><a class="reference internal" href="#introduction">Introduction</a><ul>
 <li><a class="reference internal" href="#what-is-the-initial-situation">What is the initial situation?</a></li>
 <li><a class="reference internal" href="#how-to-handle-configuration-parameters-in-robot-framework">How to handle configuration parameters in Robot Framework?</a></li>
 <li><a class="reference internal" href="#how-to-realize-a-concrete-test-suites-management">How to realize a concrete test suites management?</a></li>
@@ -387,7 +386,7 @@ limitations under the License. -->
 <li><a class="reference internal" href="#how-does-the-robot-framework-access-configuration-files">How does the Robot Framework access configuration files?</a></li>
 <li><a class="reference internal" href="#how-to-activate-the-test-suites-management-in-robot-framework">How to activate the test suites management in Robot Framework?</a></li>
 </ul>
-<ol class="arabic simple" start="2">
+</li>
 <li><a class="reference internal" href="#exercises">Exercises</a></li>
 </ol>
 </div>
@@ -769,7 +768,7 @@ when the tests are executed. Corresponding informations you will find in the doc
 <p>Hint: To learn more about how to work with parameters of different data types in JSON files please take a look at the tutorial
 <a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/100_variables_and_datatypes/variables_and_datatypes.html">100_variables_and_datatypes</a></p>
 <hr class="docutils" />
-<p><em>Tutorial v. 0.14.1 / 30.05.2023 / by MS/EMC1-XC Mai Dinh Nam Son and XC-CT/ECA3-Queckenstedt</em></p>
+<p><em>Tutorial v. 0.14.2 / 21.06.2023 / by MS/EMC1-XC Mai Dinh Nam Son and XC-CT/ECA3-Queckenstedt</em></p>
 </div>
 </div>
 </div>

--- a/900_building_testsuites/building_testsuites.html
+++ b/900_building_testsuites/building_testsuites.html
@@ -376,9 +376,16 @@ limitations under the License. -->
 <hr class="docutils" />
 <div class="section" id="table-of-content">
 <h1>Table of content</h1>
-<ol class="arabic simple">
-<li><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></li>
-<li><a class="reference internal" href="#introduction">Introduction</a><ul>
+<ol class="arabic">
+<li><p class="first"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></p>
+<div class="system-message">
+<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/900_building_testsuites/doc_src/building_testsuites.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
+<p>Duplicate explicit target name: &quot;tutorial main sections&quot;.</p>
+</div>
+<p><a class="reference external" href="https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></p>
+</li>
+<li><p class="first"><a class="reference internal" href="#introduction">Introduction</a></p>
+<ul class="simple">
 <li><a class="reference internal" href="#what-is-the-initial-situation">What is the initial situation?</a></li>
 <li><a class="reference internal" href="#how-to-handle-configuration-parameters-in-robot-framework">How to handle configuration parameters in Robot Framework?</a></li>
 <li><a class="reference internal" href="#how-to-realize-a-concrete-test-suites-management">How to realize a concrete test suites management?</a></li>
@@ -387,7 +394,8 @@ limitations under the License. -->
 <li><a class="reference internal" href="#how-to-activate-the-test-suites-management-in-robot-framework">How to activate the test suites management in Robot Framework?</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#exercises">Exercises</a></li>
+<li><p class="first"><a class="reference internal" href="#exercises">Exercises</a></p>
+</li>
 </ol>
 </div>
 <div class="section" id="introduction">

--- a/900_building_testsuites/doc_src/building_testsuites.rst
+++ b/900_building_testsuites/doc_src/building_testsuites.rst
@@ -22,6 +22,9 @@ Table of content
 
 1. `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
 
+   `Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+
+
 2. `Introduction`_
 
    * `What is the initial situation?`_

--- a/900_building_testsuites/doc_src/building_testsuites.rst
+++ b/900_building_testsuites/doc_src/building_testsuites.rst
@@ -22,9 +22,6 @@ Table of content
 
 1. `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
 
-   `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
-
-
 2. `Introduction`_
 
    * `What is the initial situation?`_

--- a/900_building_testsuites/doc_src/building_testsuites.rst
+++ b/900_building_testsuites/doc_src/building_testsuites.rst
@@ -22,7 +22,7 @@ Table of content
 
 1. `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
 
-   `Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+   `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
 
 
 2. `Introduction`_

--- a/900_building_testsuites/doc_src/building_testsuites.rst
+++ b/900_building_testsuites/doc_src/building_testsuites.rst
@@ -20,21 +20,23 @@ Building test suites in Robot Framework
 Table of content
 ----------------
 
-1. `Introduction`_
+1. `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
 
-* `What is the initial situation?`_
+2. `Introduction`_
 
-* `How to handle configuration parameters in Robot Framework?`_
+   * `What is the initial situation?`_
 
-* `How to realize a concrete test suites management?`_
+   * `How to handle configuration parameters in Robot Framework?`_
 
-* `How does the content of configuration files in JSON format look like?`_
+   * `How to realize a concrete test suites management?`_
 
-* `How does the Robot Framework access configuration files?`_
+   * `How does the content of configuration files in JSON format look like?`_
 
-* `How to activate the test suites management in Robot Framework?`_
+   * `How does the Robot Framework access configuration files?`_
 
-2. `Exercises`_
+   * `How to activate the test suites management in Robot Framework?`_
+
+3. `Exercises`_
 
 
 Introduction
@@ -537,7 +539,7 @@ Hint: To learn more about how to work with parameters of different data types in
 
 ----
 
-*Tutorial v. 0.14.1 / 30.05.2023 / by MS/EMC1-XC Mai Dinh Nam Son and XC-CT/ECA3-Queckenstedt*
+*Tutorial v. 0.14.2 / 21.06.2023 / by MS/EMC1-XC Mai Dinh Nam Son and XC-CT/ECA3-Queckenstedt*
 
 .. _TOC: `Table of content`_
 

--- a/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
+++ b/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
@@ -21,7 +21,7 @@ Table of content
 ----------------
 
 | `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
-| `Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+| `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
 
 
 | `Introduction`_

--- a/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
+++ b/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
@@ -15,10 +15,12 @@
 Static code analysis in Robot Framework
 =======================================
 
-Version 0.2.0 / 26.07.2022 / by XC-CT/ECA3-Queckenstedt
+Version 0.2.1 / 21.06.2023 / by XC-CT/ECA3-Queckenstedt
 
 Table of content
 ----------------
+
+| `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
 
 | `Introduction`_
 | `Configuration`_

--- a/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
+++ b/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
@@ -21,6 +21,8 @@ Table of content
 ----------------
 
 | `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
+| `Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+
 
 | `Introduction`_
 | `Configuration`_

--- a/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
+++ b/901_static_code_analysis/doc_src/static-code_analysis_doc.rst
@@ -21,8 +21,6 @@ Table of content
 ----------------
 
 | `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_
-| `Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
-
 
 | `Introduction`_
 | `Configuration`_

--- a/901_static_code_analysis/static-code_analysis_doc.html
+++ b/901_static_code_analysis/static-code_analysis_doc.html
@@ -378,10 +378,6 @@ limitations under the License. -->
 <h1>Table of content</h1>
 <div class="line-block">
 <div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></div>
-<div class="system-message">
-<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/901_static_code_analysis/doc_src/static-code_analysis_doc.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
-Duplicate explicit target name: &quot;tutorial main sections&quot;.</div>
-<div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
 </div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>

--- a/901_static_code_analysis/static-code_analysis_doc.html
+++ b/901_static_code_analysis/static-code_analysis_doc.html
@@ -378,6 +378,10 @@ limitations under the License. -->
 <h1>Table of content</h1>
 <div class="line-block">
 <div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></div>
+<div class="system-message">
+<p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/901_static_code_analysis/doc_src/static-code_analysis_doc.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
+Duplicate explicit target name: &quot;tutorial main sections&quot;.</div>
+<div class="line"><a class="reference external" href="https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
 </div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>

--- a/901_static_code_analysis/static-code_analysis_doc.html
+++ b/901_static_code_analysis/static-code_analysis_doc.html
@@ -373,9 +373,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
-<p>Version 0.2.0 / 26.07.2022 / by XC-CT/ECA3-Queckenstedt</p>
+<p>Version 0.2.1 / 21.06.2023 / by XC-CT/ECA3-Queckenstedt</p>
 <div class="section" id="table-of-content">
 <h1>Table of content</h1>
+<div class="line-block">
+<div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html">Tutorial main sections</a></div>
+</div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>
 <div class="line"><a class="reference internal" href="#configuration">Configuration</a></div>

--- a/901_static_code_analysis/static-code_analysis_doc.html
+++ b/901_static_code_analysis/static-code_analysis_doc.html
@@ -381,7 +381,7 @@ limitations under the License. -->
 <div class="system-message">
 <p class="system-message-title">System Message: WARNING/2 (<tt class="docutils">D:/ROBFW/components/robotframework-tutorial/901_static_code_analysis/doc_src/static-code_analysis_doc.rst</tt>, line 16); <em><a href="#tutorial-main-sections-1">backlink</a></em></p>
 Duplicate explicit target name: &quot;tutorial main sections&quot;.</div>
-<div class="line"><a class="reference external" href="https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
+<div class="line"><a class="reference external" href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html">Tutorial main sections</a></div>
 </div>
 <div class="line-block">
 <div class="line"><a class="reference internal" href="#introduction">Introduction</a></div>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here you find the online version of the rendered [tutorial
 documentation](https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html).
 
 [Tutorial main
-sections](https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html)
+sections](https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html)
 
 ## How to install
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Framework functionality.
 Here you find the online version of the rendered [tutorial
 documentation](https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html).
 
-[Tutorial main
-sections](https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html)
-
 ## How to install
 
 Clone the **robotframework-tutorial** repository to your machine.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Framework functionality.
 Here you find the online version of the rendered [tutorial
 documentation](https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html).
 
+[Tutorial main
+sections](https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html)
+
 ## How to install
 
 Clone the **robotframework-tutorial** repository to your machine.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ here:
 It is assumed that the user is already familiar with basic Robot
 Framework functionality.
 
+Here you find the online version of the rendered [tutorial
+documentation](https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html).
+
 ## How to install
 
 Clone the **robotframework-tutorial** repository to your machine.

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ It is assumed that the user is already familiar with basic Robot Framework funct
 
 Here you find the online version of the rendered `tutorial documentation <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_.
 
+`Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+
 
 How to install
 --------------

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,9 @@ An overviev about those extensions of the Robot Framework can be found here:
 
 It is assumed that the user is already familiar with basic Robot Framework functionality.
 
+Here you find the online version of the rendered `tutorial documentation <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_.
+
+
 How to install
 --------------
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ It is assumed that the user is already familiar with basic Robot Framework funct
 
 Here you find the online version of the rendered `tutorial documentation <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_.
 
-`Tutorial main sections <https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
+`Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
 
 
 How to install

--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,6 @@ It is assumed that the user is already familiar with basic Robot Framework funct
 
 Here you find the online version of the rendered `tutorial documentation <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html>`_.
 
-`Tutorial main sections <https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/HolQue/task/documentation_maintenance/robot_framework_tutorial.html>`_
-
 
 How to install
 --------------

--- a/robot_framework_tutorial.html
+++ b/robot_framework_tutorial.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+   <meta name="Tutorial" content="Robot Framework Tutorial">
+   <title>Robot Framework Tutorial</title>
+</head>
+<body bgcolor="#FFFFFF" text="#000000" link="#000000" vlink="#000000" alink="#000000">
+<hr width="100%" align="center" color="#FF8C00"/>
+<div align="center"><h1><font face="Arial" color="#000000">Robot Framework Tutorial</font></h1></div>
+<div align="center"><h1><font face="Arial" color="#000000">Main Sections</font></h1></div>
+<hr width="100%" align="center" color="#FF8C00"/>
+
+<br/>
+<div align="center">
+
+<a href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/100_variables_and_datatypes/variables_and_datatypes.html">
+<font face="Arial" color="#0000FF" size="4">
+<b>
+Variables and Data Types
+</b></font></a>
+<br/>
+<br/>
+<a href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/900_building_testsuites/building_testsuites.html">
+<font face="Arial" color="#0000FF" size="4">
+<b>
+Building Test Suites
+</b></font></a>
+<br/>
+<br/>
+<a href="https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/901_static_code_analysis/static-code_analysis_doc.html">
+<font face="Arial" color="#0000FF" size="4">
+<b>
+Static Code Analysis
+</b></font></a>
+
+</div>
+<br/>
+
+<hr width="100%" align="center" color="#FF8C00"/>
+<br/>
+<table border="1" cellspacing="0" cellpadding="6" frame="box" rules="all" align="center">
+<tr height="25" valign="middle">
+<td bgcolor="#F5F5F5" width="100%" align="left" colspan="2"><font face="Arial" color="black" size="2">
+Installation details can be found in the
+<a href="https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/README.rst">
+<font face="Arial" color="#0000FF">
+<b>README file</b></font></a>.
+</font></td>
+</tr>
+</table>
+
+<br/>
+<hr width="100%" align="center" color="#FF8C00"/>
+<div align="center"><font size="-1">Updated 21.06.2023</font></div>
+<br/>
+</body>
+</html>


### PR DESCRIPTION
This should be the main entry point in the online documentation of the tutorial:
https://htmlpreview.github.io/?https://github.com/test-fullautomation/robotframework-tutorial/blob/develop/robot_framework_tutorial.html
