### PR TITLE
Change library from .py to .exe

### DIFF
--- a/__setup/libs/CConfig.py
+++ b/__setup/libs/CConfig.py
@@ -124,7 +124,7 @@ class CConfig():
 
       sRST2HTML = None
       if sPlatformSystem == "Windows":
-         sRST2HTML = CString.NormalizePath(f"{sPythonPath}/Scripts/rst2html.py")
+         sRST2HTML = CString.NormalizePath(f"{sPythonPath}/Scripts/rst2html.exe")
       elif sPlatformSystem == "Linux":
          sRST2HTML = CString.NormalizePath(f"{sPythonPath}/rst2html.py")
       else:


### PR DESCRIPTION
Hi @test-fullautomation .
Cc @HolQue 

I have changed the library from .py to .exe to fix the error on pipeline https://github.com/test-fullautomation/RobotFramework_AIO/actions/runs/10036141461/job/27734592103?pr=327 

Ticket https://github.com/test-fullautomation/RobotFramework_AIO/issues/307.

Please help me review it.

Thank you and best regards,
Thong Hua