### PR TITLE
replace missing rst2html.py by rst2html due to new version of docutils

### DIFF
--- a/__setup/libs/CConfig.py
+++ b/__setup/libs/CConfig.py
@@ -126,7 +126,7 @@ class CConfig():
       if sPlatformSystem == "Windows":
          sRST2HTML = CString.NormalizePath(f"{sPythonPath}/Scripts/rst2html.exe")
       elif sPlatformSystem == "Linux":
-         sRST2HTML = CString.NormalizePath(f"{sPythonPath}/rst2html.py")
+         sRST2HTML = CString.NormalizePath(f"{sPythonPath}/rst2html")
       else:
          bSuccess = None
          sResult  = f"Platform system '{sPlatformSystem}' is not supported"


### PR DESCRIPTION
Hi Thomas,

This PR contains update to use executable `rst2html` file due to new version or `docutils` as I have mentioned:
https://github.com/test-fullautomation/RobotFramework_AIO/pull/447#issue-2863175429

Thank you,
Ngoan
