### PR TITLE
Increased maximum version in config files

### DIFF
--- a/100_variables_and_datatypes/config/testconfig.jsonp
+++ b/100_variables_and_datatypes/config/testconfig.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2024 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/100_variables_and_datatypes/config/tutorialconfig.jsonp
+++ b/100_variables_and_datatypes/config/tutorialconfig.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2024 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString": "Hello... Robot Framework is running now!",
 
-  "Maximum_version": "1.0.0",
+  "Maximum_version": "2.0.0",
   "Minimum_version": "0.6.0",
 
   "Project": "RobotFramework Testsuites",

--- a/100_variables_and_datatypes/config/tutorialconfig.jsonp
+++ b/100_variables_and_datatypes/config/tutorialconfig.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString": "Hello... Robot Framework is running now!",
 
-  "Maximum_version": "2.0.0",
+  "Maximum_version": "1.99.0",
   "Minimum_version": "0.6.0",
 
   "Project": "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_config_default.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_config_default.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_config_default.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_config_variant1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_config_variant1.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_config_variant2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_config_variant2.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-02/config/exercise-02_variants.jsonp
+++ b/900_building_testsuites/exercise-02/config/exercise-02_variants.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-03/config/exercise-03-A.jsonp
+++ b/900_building_testsuites/exercise-03/config/exercise-03-A.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-03/config/exercise-03-A.jsonp
+++ b/900_building_testsuites/exercise-03/config/exercise-03-A.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-03/config/exercise-03-B.jsonp
+++ b/900_building_testsuites/exercise-03/config/exercise-03-B.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-03/config/exercise-03-B.jsonp
+++ b/900_building_testsuites/exercise-03/config/exercise-03-B.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-03/config/robot_config.jsonp
+++ b/900_building_testsuites/exercise-03/config/robot_config.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-03/config/robot_config.jsonp
+++ b/900_building_testsuites/exercise-03/config/robot_config.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_config_default.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_config_default.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_config_default.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_config_variant1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_config_variant1.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_config_variant2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_config_variant2.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-04/config/exercise-04_variants.jsonp
+++ b/900_building_testsuites/exercise-04/config/exercise-04_variants.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_common.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_common.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_default.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_default.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_default.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_variant1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_variant1.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_variant2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-05/config/exercise-05_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_config_variant2.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-05/config/exercise-05_variants.jsonp
+++ b/900_building_testsuites/exercise-05/config/exercise-05_variants.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_common.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_common.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_default.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_default.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_default.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_variant1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_variant1.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_variant2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-06/config/exercise-06_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_config_variant2.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-06/config/exercise-06_variants.jsonp
+++ b/900_building_testsuites/exercise-06/config/exercise-06_variants.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-06/localconfig/exercise-06_localconfig_bench1.jsonp
+++ b/900_building_testsuites/exercise-06/localconfig/exercise-06_localconfig_bench1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-06/localconfig/exercise-06_localconfig_bench2.jsonp
+++ b/900_building_testsuites/exercise-06/localconfig/exercise-06_localconfig_bench2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-07/config/exercise-07_config_default.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.1.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-07/config/exercise-07_config_default.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_config_default.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,9 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  // "Maximum_version" : "1.0.0",
-  // "Minimum_version" : "0.6.0",
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.1.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-07/config/exercise-07_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_config_variant1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-07/config/exercise-07_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_config_variant1.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-07/config/exercise-07_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_config_variant2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-07/config/exercise-07_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_config_variant2.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-07/config/exercise-07_variants.jsonp
+++ b/900_building_testsuites/exercise-07/config/exercise-07_variants.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-07/localconfig/exercise-07_localconfig_bench1.jsonp
+++ b/900_building_testsuites/exercise-07/localconfig/exercise-07_localconfig_bench1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-07/localconfig/exercise-07_localconfig_bench2.jsonp
+++ b/900_building_testsuites/exercise-07/localconfig/exercise-07_localconfig_bench2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_common.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_common.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_default.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_default.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_default.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_default.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_variant1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_variant1.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_variant1.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_variant2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "1.0.0",
+  "Maximum_version" : "2.0.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-08/config/exercise-08_config_variant2.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_config_variant2.jsonp
@@ -16,7 +16,7 @@
 {
   "WelcomeString"   : "Hello... Robot Framework is running now!",
 
-  "Maximum_version" : "2.0.0",
+  "Maximum_version" : "1.99.0",
   "Minimum_version" : "0.6.0",
 
   "Project"         : "RobotFramework Testsuites",

--- a/900_building_testsuites/exercise-08/config/exercise-08_variants.jsonp
+++ b/900_building_testsuites/exercise-08/config/exercise-08_variants.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-08/localconfig/exercise-08_localconfig_bench1.jsonp
+++ b/900_building_testsuites/exercise-08/localconfig/exercise-08_localconfig_bench1.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/900_building_testsuites/exercise-08/localconfig/exercise-08_localconfig_bench2.jsonp
+++ b/900_building_testsuites/exercise-08/localconfig/exercise-08_localconfig_bench2.jsonp
@@ -1,4 +1,4 @@
-//  Copyright 2020-2022 Robert Bosch GmbH
+//  Copyright 2020-2026 Robert Bosch GmbH
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/__setup/robotframework_aio/release_items_RobotframeworkTutorial.json
+++ b/__setup/robotframework_aio/release_items_RobotframeworkTutorial.json
@@ -1,6 +1,6 @@
 # **************************************************************************************************************
 #
-# Copyright 2020-2024 Robert Bosch GmbH
+# Copyright 2020-2026 Robert Bosch GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
HINT:

Make sure that the installer also adapts the default configuration file which is used for level 4 configuration, to:
```
	"Maximum_version" : "1.99.0",
	"Minimum_version" : "0.6.0",
```

!!!!!!